### PR TITLE
Add an ability to preview multiple light presets same time

### DIFF
--- a/media/preview.js
+++ b/media/preview.js
@@ -2,18 +2,120 @@
 addEventListener('load', function () {
     const vscode = acquireVsCodeApi()
     const lightPresetArr = window.lightPresets.split(',')
-    const allMaps = []
+    let syncedMaps = []
+    let mbxSync
+    let hasher
 
-    lightPresetArr.forEach((preset, index) => {
+    let mapContainer = document.getElementById("container")
 
+    if (mapContainer) {
+        lightPresetArr.forEach( preset => {
+            var div = document.createElement('div')
+            div.id = preset
+            div.className = 'map'
+            mapContainer.appendChild(div)
+        })
+    }
+
+    lightPresetArr.forEach(preset => {
+        createMap(preset, window.styleUri)
+    })
+
+    if (syncedMaps.length > 1) {
+        const arrayOfMaps = syncedMaps.map(obj => obj.map)
+        mbxSync = syncMaps(arrayOfMaps)
+    }
+
+    const lastIndex = syncedMaps.length - 1
+    syncedMaps[lastIndex].hash = true
+    addHash(syncedMaps[lastIndex].map)
+
+    window.addEventListener('message', ({ data }) => {
+        
+        const { command, update } = data
+
+        if (command == 'setStyle') {
+            console.log('Got a new style:', update)
+            syncedMaps.forEach(sync => {
+                sync.map.setStyle(update)
+            })
+        } else if (command == 'updateMaps') {
+            console.log('update maps config', update)
+            // removes existing sync so can be reset again with add/removed maps
+            if (mbxSync) {
+                mbxSync()
+            }
+            
+            var mapContainer = document.getElementById('container')
+
+            // determin if adding or removing maps
+            const existingLight = syncedMaps.map(obj => obj.preset)
+            const configChanges = compareLights(existingLight, update.settings.lightPresets)
+
+            configChanges.removed.forEach( remove => {
+                const removeIdx = syncedMaps.findIndex(obj => obj.preset === remove)
+                syncedMaps[removeIdx].map.remove()
+                syncedMaps.splice(removeIdx, 1)
+                var childToRemove = document.getElementById(remove)
+                if (childToRemove) {
+                    mapContainer.removeChild(childToRemove)
+                }
+            })
+
+            configChanges.added.forEach( add => {
+                var div = document.createElement('div')
+                div.id = add
+                div.className = 'map'
+                mapContainer.appendChild(div)
+                createMap(add, update.style)
+            })
+
+            syncedMaps.forEach((sync, index) => {
+                if (sync.hash) {
+                    syncedMaps[index].hash = false 
+                    sync.map.removeControl(hasher)
+                }
+                sync.map.resize()
+            })
+
+            if (syncedMaps.length > 1) {
+                const arrayOfMaps = syncedMaps.map(obj => obj.map)
+                mbxSync = syncMaps(arrayOfMaps)
+            }
+            
+            const lastIndex = syncedMaps.length - 1
+            syncedMaps[lastIndex].hash = true
+            addHash(syncedMaps[lastIndex].map)
+
+        }
+    })
+
+    function createMap(preset, style) {
         const state = {
             projection: 'globe',
             ...vscode.getState(),
-            style: window.styleUri,
-            container: preset,
-            dirty: true,
+            style: style,
+            container: preset
         }
     
+        vscode.postMessage({ text: 'Starting Mapbox GL JS' })
+    
+        const map = new mapboxgl.Map(state)
+
+        if (preset !== 'default') {
+            map.on('style.load', () => {
+                map.setConfigProperty('basemap', 'lightPreset', preset)
+            })
+        }
+
+        syncedMaps.push({
+            preset,
+            map,
+            hash: false
+        })
+    }
+  
+    function addHash( map ) {
         const report = e => {
             console.error('caught:', e)
             vscode.postMessage({ error: e.message, stack: e.stack })
@@ -21,54 +123,42 @@ addEventListener('load', function () {
         window.addEventListener('error', report)
         window.addEventListener('unhandledrejection', report)
     
-        vscode.postMessage({ text: 'Starting Mapbox GL JS' })
-    
-        const map = new mapboxgl.Map(state)
-    
-        map.on('style.load', () => {
-            map.setConfigProperty('basemap', 'lightPreset', preset)
-        })
+        hasher = showCoordinates && new HashControl()
+        if (hasher) map.addControl(hasher)
 
-        if (lightPresetArr.length === index + 1) {
-            const hasher = showCoordinates && new HashControl()
-            if (hasher) map.addControl(hasher)
+        let dirty = true
+
+        map.on('drag', () => (dirty = true))
+        map.on('move', () => (dirty = true))
+        map.on('zoom', () => (dirty = true))
+        map.on('rotate', () => (dirty = true))
+        map.on('pitch', () => (dirty = true))
+        map.on('error', ({ error }) => report(error))
+        setInterval(() => {
+            if (!dirty) return
+            dirty = false
     
-            map.on('drag', () => (state.dirty = true))
-            map.on('move', () => (state.dirty = true))
-            map.on('zoom', () => (state.dirty = true))
-            map.on('rotate', () => (state.dirty = true))
-            map.on('pitch', () => (state.dirty = true))
-            map.on('error', ({ error }) => report(error))
-            setInterval(() => {
-                if (!state.dirty) return
-                state.dirty = false
-        
-                const center = map.getCenter()
-                const zoom = map.getZoom()
-                const bearing = map.getBearing()
-                const pitch = map.getPitch()
-                const position = { center, zoom, bearing, pitch }
-                vscode.setState(position)
-                if (hasher) hasher.set(position)
-            }, 100)
+            const center = map.getCenter()
+            const zoom = map.getZoom()
+            const bearing = map.getBearing()
+            const pitch = map.getPitch()
+            const position = { center, zoom, bearing, pitch }
+            vscode.setState(position)
+            if (hasher) hasher.set(position)
+        }, 100)
+
+    }
+    
+    function compareLights(oldArray, newArray) {
+        const uniqueValues = new Set([...oldArray, ...newArray])
+      
+        // Check if the unique set has the same length as the old and new arrays
+        if (uniqueValues.size !== oldArray.length || uniqueValues.size !== newArray.length) {
+          // Values have been added or removed
+          const added = newArray.filter((value) => !oldArray.includes(value))
+          const removed = oldArray.filter((value) => !newArray.includes(value))
+          return { added, removed }
         }
-       
-        window.addEventListener('message', ({ data }) => {
-            console.log('message recieved')
-            console.log(data)
-            const { command, style } = data
-            if (command != 'setStyle') return
-    
-            console.log('Got a new style:', style)
-            map.setStyle(data.style)
-        })
-
-        allMaps.push(map)
-
-    })
-
-    if (allMaps.length > 1) {
-        syncMaps(allMaps)
     }
 
 })

--- a/media/preview.js
+++ b/media/preview.js
@@ -1,164 +1,145 @@
 // @ts-nocheck
+
+function createMap(savedState, style, preset) {
+    console.log('Starting Mapbox GL JS')
+
+    const map = new mapboxgl.Map({
+        projection: 'globe',
+        ...savedState,
+        style,
+        container: preset,
+    })
+
+    if (preset !== 'default')
+        map.on('style.load', () => {
+            map.setConfigProperty('basemap', 'lightPreset', preset)
+        })
+
+    return map
+}
+
+function addHash({ map, report, setState }) {
+    const dirtyEvents = ['drag', 'move', 'zoom', 'rotate', 'pitch']
+    let dirty = true
+
+    const markDirty = () => (dirty = true)
+    const reportError = ({ error }) => report(error)
+
+    const hasher = window.showCoordinates && new HashControl()
+    if (hasher) {
+        map.addControl(hasher)
+        map.unhash = () => {
+            clearInterval(map.interval)
+
+            for (const event of dirtyEvents) map.off(event, markDirty)
+            map.off('error', reportError)
+
+            map.removeControl(hasher)
+            delete map.unhash
+        }
+    }
+
+    for (const event of dirtyEvents) map.on(event, markDirty)
+    map.on('error', reportError)
+
+    map.interval = setInterval(() => {
+        if (!dirty) return
+        dirty = false
+
+        const center = map.getCenter()
+        const zoom = map.getZoom()
+        const bearing = map.getBearing()
+        const pitch = map.getPitch()
+        const position = { center, zoom, bearing, pitch }
+        setState(position)
+        if (hasher) hasher.set(position)
+    }, 100)
+}
+
+function compareLights(prev, next) {
+    const unique = [...new Set([...prev, ...next])]
+    if (next.length == prev.length && next.length == unique.length) return
+
+    const added = unique.filter(d => !prev.includes(d))
+    const removed = unique.filter(d => !next.includes(d))
+    return { added, removed }
+}
+
 addEventListener('load', function () {
     const vscode = acquireVsCodeApi()
-    const lightPresetArr = window.lightPresets.split(',')
-    let syncedMaps = []
+
+    const report = e => {
+        console.error('Map error:', e)
+        vscode.postMessage({ error: e.message, stack: e.stack })
+    }
+
+    window.addEventListener('error', report)
+    window.addEventListener('unhandledrejection', report)
+
+    const maps = []
+
+    const mapContainer = document.getElementById('container')
+    if (!mapContainer) return
+
+    function mountMap(preset) {
+        const div = document.createElement('div')
+        div.id = preset
+        div.className = 'map'
+        mapContainer.appendChild(div)
+        const map = createMap(vscode.getState(), window.styleUri, preset)
+        maps.push({ preset, map })
+    }
+    function unmountMap(preset) {
+        const index = maps.findIndex(d => d.preset === preset)
+        const [{ map }] = maps.splice(index, 1)
+        map.getContainer().remove()
+        map.remove()
+    }
+
     let mbxSync
-    let hasher
-
-    let mapContainer = document.getElementById("container")
-
-    if (mapContainer) {
-        lightPresetArr.forEach( preset => {
-            var div = document.createElement('div')
-            div.id = preset
-            div.className = 'map'
-            mapContainer.appendChild(div)
-        })
+    const resync = () => {
+        if (mbxSync) {
+            mbxSync()
+            mbxSync = null
+        }
+        if (1 < maps.length) mbxSync = syncMaps(maps.map(d => d.map))
     }
 
-    lightPresetArr.forEach(preset => {
-        createMap(preset, window.styleUri)
-    })
+    const addRemoveMaps = nextPresets => {
+        const { added, removed } = compareLights(
+            maps.map(d => d.preset),
+            nextPresets
+        )
 
-    if (syncedMaps.length > 1) {
-        const arrayOfMaps = syncedMaps.map(obj => obj.map)
-        mbxSync = syncMaps(arrayOfMaps)
+        if (!added && !removed) return
+
+        for (const preset of removed) unmountMap(preset)
+        for (const preset of added) mountMap(preset)
+
+        for (const { map } of maps) {
+            map.unhash?.()
+            map.resize()
+        }
+
+        const { map: lastMap } = maps.slice(-1)[0]
+        addHash({ report, setState: vscode.setState, map: lastMap })
+        resync()
     }
 
-    const lastIndex = syncedMaps.length - 1
-    syncedMaps[lastIndex].hash = true
-    addHash(syncedMaps[lastIndex].map)
+    addRemoveMaps(window.lightPresets)
 
     window.addEventListener('message', ({ data }) => {
-        
-        const { command, update } = data
+        const { command, style, settings } = data
 
         if (command == 'setStyle') {
-            console.log('Got a new style:', update)
-            syncedMaps.forEach(sync => {
-                sync.map.setStyle(update)
-            })
+            console.log('Got a new style:', style)
+
+            for (const sync of maps) sync.map.setStyle(style)
         } else if (command == 'updateMaps') {
-            console.log('update maps config', update)
-            // removes existing sync so can be reset again with add/removed maps
-            if (mbxSync) {
-                mbxSync()
-            }
-            
-            var mapContainer = document.getElementById('container')
+            console.log('Got a config update:', settings)
 
-            // determin if adding or removing maps
-            const existingLight = syncedMaps.map(obj => obj.preset)
-            const configChanges = compareLights(existingLight, update.settings.lightPresets)
-
-            configChanges.removed.forEach( remove => {
-                const removeIdx = syncedMaps.findIndex(obj => obj.preset === remove)
-                syncedMaps[removeIdx].map.remove()
-                syncedMaps.splice(removeIdx, 1)
-                var childToRemove = document.getElementById(remove)
-                if (childToRemove) {
-                    mapContainer.removeChild(childToRemove)
-                }
-            })
-
-            configChanges.added.forEach( add => {
-                var div = document.createElement('div')
-                div.id = add
-                div.className = 'map'
-                mapContainer.appendChild(div)
-                createMap(add, update.style)
-            })
-
-            syncedMaps.forEach((sync, index) => {
-                if (sync.hash) {
-                    syncedMaps[index].hash = false 
-                    sync.map.removeControl(hasher)
-                }
-                sync.map.resize()
-            })
-
-            if (syncedMaps.length > 1) {
-                const arrayOfMaps = syncedMaps.map(obj => obj.map)
-                mbxSync = syncMaps(arrayOfMaps)
-            }
-            
-            const lastIndex = syncedMaps.length - 1
-            syncedMaps[lastIndex].hash = true
-            addHash(syncedMaps[lastIndex].map)
-
+            addRemoveMaps(settings.lightPresets)
+            for (const sync of maps) sync.map.setStyle(style)
         }
     })
-
-    function createMap(preset, style) {
-        const state = {
-            projection: 'globe',
-            ...vscode.getState(),
-            style: style,
-            container: preset
-        }
-    
-        vscode.postMessage({ text: 'Starting Mapbox GL JS' })
-    
-        const map = new mapboxgl.Map(state)
-
-        if (preset !== 'default') {
-            map.on('style.load', () => {
-                map.setConfigProperty('basemap', 'lightPreset', preset)
-            })
-        }
-
-        syncedMaps.push({
-            preset,
-            map,
-            hash: false
-        })
-    }
-  
-    function addHash( map ) {
-        const report = e => {
-            console.error('caught:', e)
-            vscode.postMessage({ error: e.message, stack: e.stack })
-        }
-        window.addEventListener('error', report)
-        window.addEventListener('unhandledrejection', report)
-    
-        hasher = showCoordinates && new HashControl()
-        if (hasher) map.addControl(hasher)
-
-        let dirty = true
-
-        map.on('drag', () => (dirty = true))
-        map.on('move', () => (dirty = true))
-        map.on('zoom', () => (dirty = true))
-        map.on('rotate', () => (dirty = true))
-        map.on('pitch', () => (dirty = true))
-        map.on('error', ({ error }) => report(error))
-        setInterval(() => {
-            if (!dirty) return
-            dirty = false
-    
-            const center = map.getCenter()
-            const zoom = map.getZoom()
-            const bearing = map.getBearing()
-            const pitch = map.getPitch()
-            const position = { center, zoom, bearing, pitch }
-            vscode.setState(position)
-            if (hasher) hasher.set(position)
-        }, 100)
-
-    }
-    
-    function compareLights(oldArray, newArray) {
-        const uniqueValues = new Set([...oldArray, ...newArray])
-      
-        // Check if the unique set has the same length as the old and new arrays
-        if (uniqueValues.size !== oldArray.length || uniqueValues.size !== newArray.length) {
-          // Values have been added or removed
-          const added = newArray.filter((value) => !oldArray.includes(value))
-          const removed = oldArray.filter((value) => !newArray.includes(value))
-          return { added, removed }
-        }
-    }
-
 })

--- a/media/preview.js
+++ b/media/preview.js
@@ -1,54 +1,74 @@
 // @ts-nocheck
 addEventListener('load', function () {
     const vscode = acquireVsCodeApi()
+    const lightPresetArr = window.lightPresets.split(',')
+    const allMaps = []
 
-    const state = {
-        projection: 'globe',
-        ...vscode.getState(),
-        style: window.styleUri,
-        container: 'map',
-        dirty: true,
-    }
+    lightPresetArr.forEach((preset, index) => {
 
-    const report = e => {
-        console.error('caught:', e)
-        vscode.postMessage({ error: e.message, stack: e.stack })
-    }
-    window.addEventListener('error', report)
-    window.addEventListener('unhandledrejection', report)
+        const state = {
+            projection: 'globe',
+            ...vscode.getState(),
+            style: window.styleUri,
+            container: preset,
+            dirty: true,
+        }
+    
+        const report = e => {
+            console.error('caught:', e)
+            vscode.postMessage({ error: e.message, stack: e.stack })
+        }
+        window.addEventListener('error', report)
+        window.addEventListener('unhandledrejection', report)
+    
+        vscode.postMessage({ text: 'Starting Mapbox GL JS' })
+    
+        const map = new mapboxgl.Map(state)
+    
+        map.on('style.load', () => {
+            map.setConfigProperty('basemap', 'lightPreset', preset)
+        })
 
-    vscode.postMessage({ text: 'Starting Mapbox GL JS' })
+        if (lightPresetArr.length === index + 1) {
+            const hasher = showCoordinates && new HashControl()
+            if (hasher) map.addControl(hasher)
+    
+            map.on('drag', () => (state.dirty = true))
+            map.on('move', () => (state.dirty = true))
+            map.on('zoom', () => (state.dirty = true))
+            map.on('rotate', () => (state.dirty = true))
+            map.on('pitch', () => (state.dirty = true))
+            map.on('error', ({ error }) => report(error))
+            setInterval(() => {
+                if (!state.dirty) return
+                state.dirty = false
+        
+                const center = map.getCenter()
+                const zoom = map.getZoom()
+                const bearing = map.getBearing()
+                const pitch = map.getPitch()
+                const position = { center, zoom, bearing, pitch }
+                vscode.setState(position)
+                if (hasher) hasher.set(position)
+            }, 100)
+        }
+       
+        window.addEventListener('message', ({ data }) => {
+            console.log('message recieved')
+            console.log(data)
+            const { command, style } = data
+            if (command != 'setStyle') return
+    
+            console.log('Got a new style:', style)
+            map.setStyle(data.style)
+        })
 
-    const map = new mapboxgl.Map(state)
+        allMaps.push(map)
 
-    const hasher = showCoordinates && new HashControl()
-    if (hasher) map.addControl(hasher)
-
-    map.on('drag', () => (state.dirty = true))
-    map.on('move', () => (state.dirty = true))
-    map.on('zoom', () => (state.dirty = true))
-    map.on('rotate', () => (state.dirty = true))
-    map.on('pitch', () => (state.dirty = true))
-    map.on('error', ({ error }) => report(error))
-
-    setInterval(() => {
-        if (!state.dirty) return
-        state.dirty = false
-
-        const center = map.getCenter()
-        const zoom = map.getZoom()
-        const bearing = map.getBearing()
-        const pitch = map.getPitch()
-        const position = { center, zoom, bearing, pitch }
-        vscode.setState(position)
-        if (hasher) hasher.set(position)
-    }, 100)
-
-    window.addEventListener('message', ({ data }) => {
-        const { command, style } = data
-        if (command != 'setStyle') return
-
-        console.log('Got a new style:', style)
-        map.setStyle(data.style)
     })
+
+    if (allMaps.length > 1) {
+        syncMaps(allMaps)
+    }
+
 })

--- a/media/preview.js
+++ b/media/preview.js
@@ -12,7 +12,9 @@ function createMap(savedState, style, preset) {
 
     if (preset !== 'default')
         map.on('style.load', () => {
-            map.setConfigProperty('basemap', 'lightPreset', preset)
+            try {
+                map.setConfigProperty('basemap', 'lightPreset', preset)
+            } catch {}
         })
 
     return map

--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
                             "type": "string",
                             "enum": ["dawn", "day", "dusk", "night"]
                         },
-                        "default": ["day"],
-                        "description": "Select one or more light preset option if using the Mapbox Standard Style",
+                        "description": "Select one or more light preset option if using the Mapbox Standard Style. Only works with the Standard style with light presets, not custom styles.",
                         "uniqueItems": true,
                         "validationErrorMessage": "Duplicate options are not allowed",
                         "when": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
                     },
                     "mapboxPreview.version": {
                         "type": "string",
-                        "default": "2.10.0",
+                        "default": "3.0.1",
                         "pattern": "^\\d+\\.\\d+\\.\\d+(?:[+-][A-Za-z0-9+.-]+(?:.\\d+)?)?$",
                         "patternErrorMessage": "Must be a valid SemVer string",
                         "description": "Version of Mapbox GL JS to use"
@@ -64,6 +64,26 @@
                         "type": "boolean",
                         "default": false,
                         "description": "Controls whether the coordinate editor is visible in the preview panel"
+                    },
+                    "mapboxPreview.lightPresets": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": ["dawn", "day", "dusk", "night"]
+                        },
+                        "default": ["day"],
+                        "description": "Select one or more light preset option if using the Mapbox Standard Style",
+                        "uniqueItems": true,
+                        "validationErrorMessage": "Duplicate options are not allowed",
+                        "when": {
+                            "not": {
+                                "properties": {
+                                    "mapboxPreview.version": {
+                                        "pattern": "^(?:3\\.[0-9]+\\.[0-9]+|[4-9]\\d*\\.\\d+\\.\\d+)$"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,12 @@
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "enum": ["dawn", "day", "dusk", "night"]
+                            "enum": [
+                                "dawn",
+                                "day",
+                                "dusk",
+                                "night"
+                            ]
                         },
                         "description": "Select one or more light preset option if using the Mapbox Standard Style. Only works with the Standard style with light presets, not custom styles.",
                         "uniqueItems": true,
@@ -135,6 +140,7 @@
     },
     "devDependencies": {
         "@types/node": "^16.11.7",
+        "@types/node-fetch": "^2.6.9",
         "@types/vscode": "^1.47.0",
         "@types/vscode-webview": "^1.57.0",
         "@typescript-eslint/eslint-plugin": "^5.30.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,6 @@ class MapboxPreview {
     private constructor(panel: vscode.WebviewPanel, fileUri: vscode.Uri) {
         this.panel = panel
         this.fileUri = fileUri
-
         this.update()
         this.panel.onDidDispose(() => this.dispose(), null, this.disposables)
 
@@ -114,9 +113,15 @@ class MapboxPreview {
             null,
             this.disposables
         )
-
+        
         vscode.workspace.onDidSaveTextDocument(
             document => MapboxPreview.refreshFile(document),
+            null,
+            this.disposables
+        )
+
+        vscode.workspace.onDidChangeConfiguration( 
+            event => this.update(),
             null,
             this.disposables
         )
@@ -146,9 +151,8 @@ class MapboxPreview {
         if (!this.currentPanel.fileUri && loadable)
             this.currentPanel.fileUri = document.uri
 
-        if ((!same && !isSettings) || !this.currentPanel.fileUri) return
+        if (!same || !this.currentPanel.fileUri || isSettings) return
 
-        console.log('Refreshing')
         this.currentPanel.update()
     }
 
@@ -196,17 +200,12 @@ class MapboxPreview {
             .get('mapboxPreview.showCoordinates', false)
 
         const lightPresets = vscode.workspace
-        .getConfiguration()
-        .get('mapboxPreview.lightPresets', ['day'])
-
-        console.log('lightPresets',lightPresets)
+            .getConfiguration()
+            .get('mapboxPreview.lightPresets', ['day'])
 
         const settings = { path, token, version, showCoordinates, lightPresets }
         const nextSettings = JSON.stringify(settings)
         const sameSettings = this.lastSettings == nextSettings
-        console.log('sameSettings', sameSettings)
-        console.log('nextsettings', nextSettings)
-        console.log('lastsettings', this.lastSettings)
         this.lastSettings = nextSettings
 
         this.panel.title = `Mapbox: ${path}`


### PR DESCRIPTION
Added the ability to view multiple Standard style map views based on light preset setting:

![Vv1O86nnJaLK7ZcsEOaLC09L1KadhqNq9WNvqPkBmgxpZyAr8rP4-Tfk3b4QwTYwbEOfjGP95JKFStQixv48ovjArHD40yGeQ9mNHnerch8DErKyJmB2zSqndJsm](https://github.com/AlexanderBelokon/vscode-mapbox-preview/assets/2847668/f655f4a5-0cd9-40aa-934f-cd30be98b774)


Using `mapbox-gl-sync-move` to sync changes between multiple maps. 